### PR TITLE
Embedded

### DIFF
--- a/embedded/badger/badger.ino
+++ b/embedded/badger/badger.ino
@@ -345,8 +345,10 @@ void	scrollingMessage(const char * msg)
 	delay(300);
 	messageLength = strlen(msg);
 	totalScroll = messageLength - lcdLength;
-  if (totalScroll <= 0)
-    totalScroll = 0;
+	if (totalScroll <= 0)
+	{
+		totalScroll = 0;
+	}
 	detachInterrupt(BUTTON);
 	for (int i = totalScroll; i >= 0; i--)
 	{


### PR DESCRIPTION
Fix infinite loop when the displayed message is shorter than the screen length.
Displaying message when the badger is trying to connect to the Wifi.
Delete the Serial.begin() no need anymore for production.
Prettify the code with tabs instead of spaces.
Fix error displaying when the badger can't connect to the server. If the server wasn't connected the badger tried to get the modes and display no event instead of nothing.